### PR TITLE
Update IANA

### DIFF
--- a/main.md
+++ b/main.md
@@ -8,7 +8,7 @@ keyword = ["security", "oauth2"]
 
 [seriesInfo]
 name = "Internet-Draft"
-value = "draft-ietf-oauth-rar-09"
+value = "draft-ietf-oauth-rar-10"
 stream = "IETF"
 status = "standard"
 
@@ -1404,10 +1404,13 @@ In this use case, the AS authenticates the requester, who is not the patient, an
 
    [[ To be removed from the final specification ]]
 
+   -10
+
+    * Updated IANA registrations
+
    -09
 
    * Incorporated feedback by Hannes as document shepherd
-   * Updated IANA registrations
 
    -08
 

--- a/main.md
+++ b/main.md
@@ -986,7 +986,7 @@ Claim Name:
 : `authorization_details`
 
 Claim Description:
-: The claim `authorization_details` contains, a JSON array of JSON objects representing the rights of the access token. Each JSON object contains the data to specify the authorization requirements for a certain type of resource.
+: The claim `authorization_details` contains a JSON array of JSON objects representing the rights of the access token. Each JSON object contains the data to specify the authorization requirements for a certain type of resource.
 
 Change Controller:
 : IESG
@@ -1003,7 +1003,7 @@ Name:
 : `authorization_details`
 
 Description:
-: The member `authorization_details` contains, a JSON array of JSON objects representing the rights of the access token. Each JSON object contains the data to specify the authorization requirements for a certain type of resource.
+: The member `authorization_details` contains a JSON array of JSON objects representing the rights of the access token. Each JSON object contains the data to specify the authorization requirements for a certain type of resource.
  
 Change Controller:
 : IESG

--- a/main.md
+++ b/main.md
@@ -741,7 +741,7 @@ with invalid values, or if required fields are missing, the AS MUST abort proces
 
 In order to enable the RS to enforce the authorization details as approved in the authorization process, the AS MUST make this data available to the RS. The AS MAY add the `authorization_details` field to access tokens in JWT format or to Token Introspection responses. 
 
-## JWT-based Access Tokens
+## JWT-based Access Tokens {#jwt_based_access_tokens}
 
 If the access token is a JWT [@!RFC7519], the AS is RECOMMENDED to add the `authorization_details` object, filtered to the specific audience, as a top-level claim. 
 
@@ -793,7 +793,7 @@ In this case, the AS added the following example claims to the JWT-based access 
 * `txn`: transaction id used to trace the transaction across the services of provider `example.com`
 * `debtorAccount`: API-specific field containing the debtor account. In the example, this account was not passed in the authorization details but selected by the user during the authorization process. The field `user_role` conveys the role the user has with respect to this particular account. In this case, they is the owner. This data is used for access control at the payment API (the RS).
 
-## Token Introspection 
+## Token Introspection {#token_introspection}
 
 In the case of opaque access tokens, the data provided to a certain RS is determined using the RS's identifier with the AS (see [@I-D.ietf-oauth-jwt-introspection-response], section 3). 
 
@@ -986,13 +986,30 @@ Claim Name:
 : `authorization_details`
 
 Claim Description:
-: The request parameter `authorization_details` contains, in JSON notation, an array of objects. Each JSON object contains the data to specify the authorization requirements for a certain type of resource.
+: The claim `authorization_details` contains, a JSON array of JSON objects representing the rights of the access token. Each JSON object contains the data to specify the authorization requirements for a certain type of resource.
+
+Change Controller:
+: IESG
+
+Specification Document(s):
+: (#jwt_based_access_tokens) of this document
+
+## OAuth Token Introspection Response
+
+This specification requests registration of the following value in the IANA "OAuth Token Introspection Response Registry" established by [@!RFC7662]. 
+
+{spacing="compact"}
+Name:
+: `authorization_details`
+
+Description:
+: The member `authorization_details` contains, a JSON array of JSON objects representing the rights of the access token. Each JSON object contains the data to specify the authorization requirements for a certain type of resource.
  
 Change Controller:
 : IESG
 
 Specification Document(s):
-: (#authz_details) of this document
+: (#token_introspection) of this document
 
 ## OAuth Authorization Server Metadata
 

--- a/main.md
+++ b/main.md
@@ -1407,6 +1407,7 @@ In this use case, the AS authenticates the requester, who is not the patient, an
    -09
 
    * Incorporated feedback by Hannes as document shepherd
+   * Updated IANA registrations
 
    -08
 


### PR DESCRIPTION
Simply fixes up the IANA section to include a registration for a parameter defined within the spec. No normative changes.